### PR TITLE
fix: prevent empty names as valid player entries, and clear form on submission

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -60,10 +60,15 @@ function addPlayer(event) {
   event.preventDefault();
 
   const playerName = document.getElementById("playerNameInput").value;
+  if (playerName === "") {
+    return;
+  }
+
   State.playerList.push(playerName);
   savePlayersLocally();
 
   populatePlayerListHtml();
+  document.getElementById("playerNameInput").value = "";
 }
 
 function canFactionBePicked(faction, selectedFactions) {
@@ -79,7 +84,6 @@ function canFactionBePicked(faction, selectedFactions) {
 function randomizeFactions() {
   const availableFactions = Array.from(DATA.FACTION_LIST_BY_REACH);
   const numPlayers = State.playerList.length;
-  const players = Array.from(State.playerList);
   const minReach = DATA.REACH_BY_PLAYER_COUNT[numPlayers];
   var currentReach = 0;
   const selectedFactions = [];


### PR DESCRIPTION
This prevents submission of `""` as a player name. Also clear out the entry to allow for easier data entry, and prevent double name submission.