### PR TITLE
use baskerville font

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
   <meta name="description" content="All Random All Root">
   <meta name="author" content="Ryan Haswell">
   <link rel='stylesheet' href="./stylesheets/style.css">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Libre+Baskerville">
 </head>
 
 <body>

--- a/stylesheets/style.css
+++ b/stylesheets/style.css
@@ -1,5 +1,9 @@
 @import "maps.css";
 
+body {
+    font-family: 'Libre Baskerville', serif;
+}
+
 ul.seat-list {
     list-style-type: decimal
 }


### PR DESCRIPTION
Previous PR Failed build on jekyll. I suspect it had to do with the invalid CSS in that commit, but I am not sure, since I cannot access the builds?

Previous PR had no font change effect, since CSS `"Libre+Baskerville"` was not the right string.

Since I don't have access to the Jekyll build reports I can only suspect that this was the problem. Re-opening this changelist.